### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/poc.js
+++ b/poc.js
@@ -1,5 +1,0 @@
-const merge = require('./dist').default
-
-console.log(`Before: ${{}.polluted}`)
-merge([{}, JSON.parse('{"__proto__": {"polluted": true}, "foo": 2}')])
-console.log(`After: ${{}.polluted}`)

--- a/poc.js
+++ b/poc.js
@@ -1,0 +1,5 @@
+const merge = require('./dist').default
+
+console.log(`Before: ${{}.polluted}`)
+merge([{}, JSON.parse('{"__proto__": {"polluted": true}, "foo": 2}')])
+console.log(`After: ${{}.polluted}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ function mergeObjects ( target, source ) {
 
   for ( const key in source ) {
 
-    if ( key === 'constructor' || key === 'prototype' || key === '__proto__' ) break;
+    if ( key === 'constructor' || key === 'prototype' || key === '__proto__' ) continue;
 
     const value = source[key];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,7 @@ function mergeObjects ( target, source ) {
 
   for ( const key in source ) {
 
-    if ( isPrototypePolluted ( key ) ) {
-
-      continue;
-
-    }
+    if ( key === 'constructor' || key === 'prototype' || key === '__proto__' ) break;
 
     const value = source[key];
 
@@ -49,12 +45,6 @@ function mergeObjects ( target, source ) {
   }
 
   return target;
-
-}
-
-function isPrototypePolluted ( key ) {
-
-  return [ '__proto__', 'constructor', 'prototype' ].includes( key );
 
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,12 @@ function mergeObjects ( target, source ) {
 
   for ( const key in source ) {
 
+    if ( isPrototypePolluted ( key ) ) {
+
+      continue;
+
+    }
+
     const value = source[key];
 
     if ( isPrimitive ( value ) ) {
@@ -43,6 +49,12 @@ function mergeObjects ( target, source ) {
   }
 
   return target;
+
+}
+
+function isPrototypePolluted ( key ) {
+
+  return [ '__proto__', 'constructor', 'prototype' ].includes( key );
 
 }
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`plain-object-merge` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-plain-object-merge

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const merge = require('plain-object-merge')

console.log('Before: ' + {}.polluted)
merge([{}, JSON.parse('{"__proto__": {"polluted": true}}')])
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i plain-object-merge # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105176366-2ec0e380-5b4b-11eb-9291-1b99eae1474b.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
