### PR TITLE
Disallow prototype path override by checking magic attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,18 @@
 import clone from 'plain-object-clone';
 import * as isPrimitive from 'is-primitive';
 
+const ILLEGAL_KEYS = new Set(["prototype", "constructor", "__proto__"]);
+
+function isIllegalKey(key: string): Boolean {
+  return ILLEGAL_KEYS.has(key);
+}
+
+function disallowProtopath(key: string): void {
+  if (isIllegalKey(key)) {
+    throw new Error("Unsafe key encountered: " + key)
+  }
+}
+
 /* MERGE */
 
 function merge ( objects: any[] ) {
@@ -23,6 +35,7 @@ function merge ( objects: any[] ) {
 function mergeObjects ( target, source ) {
 
   for ( const key in source ) {
+    disallowProtopath(key);
 
     const value = source[key];
 

--- a/test/index.js
+++ b/test/index.js
@@ -15,4 +15,8 @@ describe ( 'Plain Object Merge', it => {
 
   });
 
+  it('disallows prototype pollution', t => {
+    t.throws(() => merge([{}, JSON.parse('{"__proto__": {"polluted": true}}')]))
+  })
+
 });


### PR DESCRIPTION
### 📊 Metadata *

plain-object-merge is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-plain-object-merge/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
const merge = require('plain-object-merge')

console.log('Before: ' + {}.polluted)
merge([{}, JSON.parse('{"__proto__": {"polluted": true}}')])
console.log('After: ' + {}.polluted)
```

Execute the following commands in the terminal:

```
npm i plain-object-merge # install vulnerable package
node poc.js # run the PoC
```

Check the output:

```
Before: undefined
After: true
```


### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106098345-e4e58800-615e-11eb-8fcb-07967e8f72d0.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106098365-ef078680-615e-11eb-861d-192d09b726c8.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/106098789-a2707b00-615f-11eb-9af5-9db744ef24f1.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1801
